### PR TITLE
Remove cluster dependency from image building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    services:
-      kind:
-        image: kindest/node:v1.21.2
-        ports:
-          - 6443:6443
-          - 8080:8080
 
     steps:
     - name: Checkout repository
@@ -46,10 +40,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.22.3'
-
-    - name: Create KinD cluster 
-      run: |
-        kind create cluster --name my-cluster
 
     - name: Set up Operator SDK
       run: |

--- a/Makefile
+++ b/Makefile
@@ -238,13 +238,13 @@ build-agent-ocp: ## Build the Node Agent's image for OCP.
 	$(CONTAINER_TOOL) build --build-arg="BASE_IMAGE=$(OCP_IMAGE)" -f build/Dockerfile.nodeagent -t intel/power-node-agent_ocp-$(OCP_VERSION):v$(VERSION) .
 
 .PHONY: images
-images: generate manifests install build-controller build-agent ## Build the Manager and Node Agent images.
+images: generate manifests build-controller build-agent ## Build the Manager and Node Agent images.
 
 .PHONY: docker-build
 docker-build: images ## Alias for images target.
 
 .PHONY: images-ocp
-images-ocp: generate manifests install build-controller-ocp build-agent-ocp ## Build the Manager and Node Agent images for OCP.
+images-ocp: generate manifests build-controller-ocp build-agent-ocp ## Build the Manager and Node Agent images for OCP.
 
 .PHONY: push
 push: ## Push docker image with the manager.


### PR DESCRIPTION
Dependency on a cluster is not needed when building images.