### PR TITLE
Add MSR metrics component (#30)

### DIFF
--- a/build/nodeagent/main.go
+++ b/build/nodeagent/main.go
@@ -175,7 +175,15 @@ func main() {
 	)
 	defer perfEventClient.Close()
 
-	monitoring.RegisterMetrics(perfEventClient, powerLibrary, ctrl.Log)
+	msrClient := metrics.NewMSRClient(
+		ctrl.Log.WithName("clients").WithName("MSRClient"),
+		powerLibrary,
+	)
+	defer msrClient.Close()
+
+	logger := ctrl.Log.WithName(monitoring.LogTopName)
+	monitoring.RegisterPerfEventCollectors(perfEventClient, powerLibrary, logger)
+	monitoring.RegisterMSRCollectors(msrClient, powerLibrary, logger)
 
 	if err = (&controller.PowerProfileReconciler{
 		Client:       mgr.GetClient(),

--- a/internal/metrics/msr_client.go
+++ b/internal/metrics/msr_client.go
@@ -1,0 +1,288 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/intel/kubernetes-power-manager/pkg/util"
+	"github.com/intel/power-optimization-library/pkg/power"
+)
+
+// Func definitions for unit testing
+var (
+	newMSRReaderFunc func(int) (msrReader, error) = newMSRReader
+)
+
+// MSR offsets definitions
+const (
+	tscOffset   uint64 = 0x00000010
+	mperfOffset uint64 = 0x000000E7
+	aperfOffset uint64 = 0x000000E8
+
+	raplOffset                uint64 = 0xC0010299
+	totalPkgEnergyTicksOfsset uint64 = 0xC001029B
+	totalCoreEnergyOffset     uint64 = 0xC001029A
+)
+
+const (
+	workersInterval time.Duration = 1 * time.Second
+)
+
+var (
+	// ErrMSRReaderMissing is returned when called MSR reader file handle couldn't
+	// be created due to startup error and not due to single offset read error of
+	// active handle.
+	ErrMSRReaderMissing error = errors.New("MSR reader missing")
+
+	// ErrCStateResidencyInsufficientData is returned when msrReader.read() method returned error
+	// during runtime. We assume that the issue is temporary since MSR file handle for that CPU
+	// was created properly and was readable.
+	ErrCStateResidencyInsufficientData error = errors.New("insufficient data to calculate C-state residency")
+
+	// ErrCStateResidencyNotYetCalculated is returned when trying to read C0 and Cx residency values when they
+	// were not yet calculated (meaning time period of 2 intervals has not yet passed since client creation).
+	ErrCStateResidencyNotYetCalculated error = errors.New("not yet calculated C-state residency")
+)
+
+// MSRClient is thread safe client to MSR pseudofiles located by default in
+// /dev/cpuX/ directories. Single instance should be created using constructor
+// and passed as a pointer.
+type MSRClient struct {
+	readers map[uint]msrReader
+	host    power.Host
+	log     logr.Logger
+
+	workersCancel       context.CancelFunc
+	workersWaitGroup    sync.WaitGroup
+	c0ResPercentResults sync.Map
+}
+
+// MSRClient opens handles to all CPUs found on the system during power-library
+// initialization. Handles need to be closed after client is no longer in use.
+// Client also starts worker goroutine per CPU to constantly calculate C-state
+// residency of that core in specified interval (set as const in in metrics package).
+// host is instance of power-library Host that exposes system topology.
+// Returns pointer to MSRClient that should be the only instance created within binary.
+func NewMSRClient(log logr.Logger, host power.Host) *MSRClient {
+	ctx, cancel := context.WithCancel(context.Background())
+	msr := MSRClient{
+		readers:       make(map[uint]msrReader),
+		host:          host,
+		log:           log,
+		workersCancel: cancel,
+	}
+
+	msr.addReaders()
+	msr.startC0ResidencyWorkers(ctx)
+	msr.log.V(4).Info("New MSRClient created")
+
+	return &msr
+}
+
+type c0ResidencyResult struct {
+	value uint8
+	err   error
+}
+
+func (msr *MSRClient) Close() {
+	msr.log.V(4).Info("Closing all registered readers")
+	for cpuId, reader := range msr.readers {
+		if err := reader.close(); err != nil {
+			msr.log.V(5).Error(err, "error while closing reader", "cpu id", cpuId)
+		}
+	}
+
+	msr.log.V(4).Info("Closing all C-state residency worker goroutines")
+	msr.workersCancel()
+	msr.workersWaitGroup.Wait()
+}
+
+func (msr *MSRClient) GetC0ResidencyPercent(cpu power.Cpu) (uint8, error) {
+	logger := msr.log.WithValues("cpu", cpu.GetID())
+
+	result, ok := msr.c0ResPercentResults.Load(cpu.GetID())
+	if !ok {
+		// Map keys are added on client creation so this branch should not happen at all.
+		logger.V(5).Error(ErrMSRReaderMissing, "unexpected behavior, ensure MSRClient was created using constructor")
+		return 0, ErrMSRReaderMissing
+	}
+	r := result.(c0ResidencyResult)
+
+	return r.value, r.err
+}
+
+func (msr *MSRClient) GetCxResidencyPercent(cpu power.Cpu) (uint8, error) {
+	logger := msr.log.WithValues("cpu", cpu.GetID())
+
+	result, ok := msr.c0ResPercentResults.Load(cpu.GetID())
+	if !ok {
+		// Map keys are added on client creation so this branch should not happen at all.
+		logger.V(5).Error(ErrMSRReaderMissing, "unexpected behavior, ensure MSRClient was created using constructor")
+		return 0, ErrMSRReaderMissing
+	}
+	r := result.(c0ResidencyResult)
+
+	return 100 - r.value, r.err
+}
+
+func (msr *MSRClient) GetPackageEnergyConsumption(pkg power.Package) (float64, error) {
+	cpu := (*pkg.CPUs())[0]
+
+	energyTicks, err := msr.readMetric(cpu.GetID(), totalPkgEnergyTicksOfsset, pkg.GetID(), packageLogKey)
+	if err != nil {
+		return 0.0, err
+	}
+	energyUnits, err := msr.getRAPLEnergyUnit(cpu)
+	if err != nil {
+		return 0.0, err
+	}
+	joulesConsumed := float64(energyTicks) * energyUnits
+
+	return joulesConsumed, nil
+}
+
+func (msr *MSRClient) GetCoreEnergyConsumption(core power.Core) (float64, error) {
+	cpu := (*core.CPUs())[0]
+
+	energyTicks, err := msr.readMetric(cpu.GetID(), totalCoreEnergyOffset, core.GetID(), packageLogKey)
+	if err != nil {
+		return 0.0, err
+	}
+	energyUnits, err := msr.getRAPLEnergyUnit(cpu)
+	if err != nil {
+		return 0.0, err
+	}
+	joulesConsumed := float64(energyTicks) * energyUnits
+
+	return joulesConsumed, nil
+}
+
+func (msr *MSRClient) getRAPLEnergyUnit(cpu power.Cpu) (float64, error) {
+	raplMeta, err := msr.readMetric(cpu.GetID(), raplOffset, cpu.GetID(), cpuLogKey)
+	if err != nil {
+		return 0, err
+	}
+	const energyUnitBits uint64 = 0b0001111100000000
+	exponent := (raplMeta & energyUnitBits) >> 8
+
+	return 1 / math.Pow(2, float64(exponent)), nil
+}
+
+// scopeid and scopeName are passed for user friendly logs
+func (msr *MSRClient) readMetric(cpu uint, offset uint64, scopeId uint, scopeName string) (uint64, error) {
+	logger := msr.log.WithValues("cpu", cpu, "scope id", scopeId, "scope name", scopeName)
+
+	reader, ok := msr.readers[cpu]
+	if !ok {
+		logger.V(5).Error(ErrMSRReaderMissing, "")
+		return 0, ErrMSRReaderMissing
+	}
+	val, err := reader.read(offset)
+	if err != nil {
+		return 0, err
+	}
+
+	return val, nil
+}
+
+func (msr *MSRClient) addReaders() {
+	util.IterateOverCPUs(msr.host, func(cpu power.Cpu, _ power.Core, _ power.Die, _ power.Package) {
+		logger := msr.log.WithValues("cpu", cpu.GetID())
+
+		reader, err := newMSRReaderFunc(int(cpu.GetID()))
+		if err != nil {
+			logger.Error(err, "error while creating event reader")
+			return
+		}
+		msr.readers[cpu.GetID()] = reader
+
+		logger.V(5).Info("Initialized reader")
+	})
+}
+
+// startC0ResidencyWorkers first checks if MSR readers needed for workers calculations are readable.
+// If yes, it starts goroutine for each CPU, if not, it logs an error.
+func (msr *MSRClient) startC0ResidencyWorkers(ctx context.Context) {
+	util.IterateOverCPUs(msr.host, func(cpu power.Cpu, _ power.Core, _ power.Die, _ power.Package) {
+		logger := msr.log.WithValues("cpu", cpu.GetID())
+
+		// Test if MSR readers are active before starting worker goroutine
+		_, errTsc := msr.readMetric(cpu.GetID(), tscOffset, cpu.GetID(), cpuLogKey)
+		_, errMperf := msr.readMetric(cpu.GetID(), mperfOffset, cpu.GetID(), cpuLogKey)
+		if errMperf == ErrMSRReaderMissing || errTsc == ErrMSRReaderMissing {
+			logger.Error(ErrMSRReaderMissing, "not starting C-state residency worker goroutine")
+			msr.c0ResPercentResults.Store(cpu.GetID(), c0ResidencyResult{err: ErrMSRReaderMissing})
+			return
+		}
+
+		msr.workersWaitGroup.Add(1)
+		msr.c0ResPercentResults.Store(cpu.GetID(), c0ResidencyResult{err: ErrCStateResidencyNotYetCalculated})
+		go msr.c0ResidencyWorker(cpu, ctx)
+		logger.V(5).Info("Started C-state residency worker goroutine")
+	})
+}
+
+// c0ResidencyWorker calculates percent of CPU C0-state residency in last time interval (specified by
+// const variable). It takes as arguments CPU that will be monitored and context - used only for cancellation.
+// At the end of each calculation loop it updates the value stored in sync.Map (client field) for that CPU.
+// It pushes first value after 2 intervals, and then updates it every interval. Worker supports error handling.
+func (msr *MSRClient) c0ResidencyWorker(cpu power.Cpu, ctx context.Context) {
+	defer msr.workersWaitGroup.Done()
+	logger := msr.log.WithValues("cpu", cpu.GetID(), "worker", "C-state residency")
+
+	var (
+		tsc      uint64
+		tscErr   error = ErrCStateResidencyNotYetCalculated
+		mperf    uint64
+		mperfErr = ErrCStateResidencyNotYetCalculated
+
+		prevTSC      uint64
+		prevTSCErr   error
+		prevMPERF    uint64
+		prevMPERFErr error
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.V(5).Info("cancellation signal received, exiting work")
+			return
+		case <-time.After(workersInterval):
+			prevTSC, prevTSCErr = tsc, tscErr
+			if tsc, tscErr = msr.readMetric(cpu.GetID(), tscOffset, cpu.GetID(), cpuLogKey); tscErr != nil {
+				msr.c0ResPercentResults.Store(cpu.GetID(), c0ResidencyResult{err: tscErr})
+				logger.V(5).Error(mperfErr, "error retrieving TSC value, continuing to next iteration")
+				continue
+			}
+
+			prevMPERF, prevMPERFErr = mperf, mperfErr
+			if mperf, mperfErr = msr.readMetric(cpu.GetID(), mperfOffset, cpu.GetID(), cpuLogKey); mperfErr != nil {
+				msr.c0ResPercentResults.Store(cpu.GetID(), c0ResidencyResult{err: mperfErr})
+				logger.V(5).Error(mperfErr, "error retrieving MPERF value, continuing to next iteration")
+				continue
+			}
+
+			// tsc <= prevTSC check is there to prevent dividing by 0 that would happen
+			// when 2 consecutive TSC reads will have the same value. We also handle
+			// situation in which counters were reset and prev is bigger than current.
+			// Both situation very unlikely to happen.
+			if prevTSCErr != nil || prevMPERFErr != nil || tsc <= prevTSC || mperf < prevMPERF {
+				continue
+			}
+
+			c0ResPercentFloat := (float64(mperf-prevMPERF) / float64(tsc-prevTSC)) * 100
+			// Both TSC and MPERF counters are going up by a lot every milisecond. MPERF is retrieved after TSC so
+			// in situation when C0-state residency is close to 100% those nanoseconds between retrieval of both values
+			// might cause MPERF > TSC which will yield value >100%. The same could happen when C0-state residency
+			// is close to 0%, then the calculated value will be a little larger than actual. Since we want to return %,
+			// and the calcuations cannot be fully accurate, we round to integers.
+			c0ResPercent := uint8(math.Round(c0ResPercentFloat))
+
+			msr.c0ResPercentResults.Store(cpu.GetID(), c0ResidencyResult{value: c0ResPercent})
+		}
+	}
+}

--- a/internal/metrics/msr_client_test.go
+++ b/internal/metrics/msr_client_test.go
@@ -1,0 +1,227 @@
+package metrics
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/intel/kubernetes-power-manager/pkg/util"
+	"github.com/intel/power-optimization-library/pkg/power"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap/zapcore"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+type testMSRReader struct {
+	tscCounter uint64
+	counter    uint64
+	mock.Mock
+}
+
+func newTestMSRReader(_ int) (msrReader, error) {
+	msr := &testMSRReader{}
+	msr.On("close").Return(nil)
+	return msr, nil
+}
+
+func (msr *testMSRReader) close() error { return msr.Called().Error(0) }
+
+func (msr *testMSRReader) read(offset uint64) (uint64, error) {
+	// There is counter specifically for tsc as it has to be greater than mperf
+	if offset == tscOffset {
+		msr.tscCounter += (rand.Uint64N(1000) + 1000)
+		return msr.tscCounter, nil
+	}
+	if offset == raplOffset {
+		// Default raw RAPL unit value for AMD processors
+		return 659459, nil
+	}
+	// Regular testing counter for everything else
+	msr.counter += rand.Uint64N(1000)
+	return msr.counter, nil
+}
+
+func TestNewMSRClient(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true), func(opts *zap.Options) {
+		opts.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}))
+	origFunc := newMSRReaderFunc
+	defer func() {
+		newMSRReaderFunc = origFunc
+	}()
+
+	newMSRReaderFunc = newTestMSRReader
+	powerLibMock := initializeHostMock()
+
+	client := NewMSRClient(ctrl.Log.WithName("testing"), powerLibMock)
+	defer client.Close()
+	// Assert all readers were added properly and are readable
+	util.IterateOverCPUs(powerLibMock, func(cpu power.Cpu, _ power.Core, _ power.Die, _ power.Package) {
+		reader, ok := client.readers[cpu.GetID()]
+		assert.True(t, ok)
+		val, err := reader.read(0x0)
+		assert.Nil(t, err)
+		assert.Greater(t, val, uint64(0))
+	})
+
+	// Assert all workers were started properly and are updating values
+	wg := sync.WaitGroup{}
+	util.IterateOverCores(powerLibMock, func(core power.Core, _ power.Die, _ power.Package) {
+		wg.Add(1)
+		cpu := (*core.CPUs())[0]
+		go func() {
+			defer wg.Done()
+			// Wait for the completion of the first two iterations of the worker loop, add 50ms for calculations.
+			time.Sleep(2*workersInterval + 50*time.Millisecond)
+
+			result, ok := client.c0ResPercentResults.Load(cpu.GetID())
+			assert.True(t, ok)
+			r := result.(c0ResidencyResult)
+			assert.Nil(t, r.err)
+		}()
+	})
+	wg.Wait()
+}
+
+func TestNewMSRClientWithErrors(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true), func(opts *zap.Options) {
+		opts.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}))
+	origFunc := newMSRReaderFunc
+	defer func() {
+		newMSRReaderFunc = origFunc
+	}()
+
+	newMSRReaderFunc = func(i int) (msrReader, error) { return nil, fmt.Errorf("reader startup error") }
+	powerLibMock := initializeHostMock()
+
+	client := NewMSRClient(ctrl.Log.WithName("testing"), powerLibMock)
+	defer client.Close()
+	// Assert no readers were started
+	util.IterateOverCPUs(powerLibMock, func(cpu power.Cpu, _ power.Core, _ power.Die, _ power.Package) {
+		_, ok := client.readers[cpu.GetID()]
+		assert.False(t, ok)
+	})
+	// Assert no worker goroutines were started
+	util.IterateOverCores(powerLibMock, func(core power.Core, _ power.Die, _ power.Package) {
+		cpu := (*core.CPUs())[0]
+		result, ok := client.c0ResPercentResults.Load(cpu.GetID())
+		assert.True(t, ok)
+		r := result.(c0ResidencyResult)
+		assert.ErrorIs(t, r.err, ErrMSRReaderMissing)
+	})
+}
+
+func TestGetC0ResidencyPercent(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true), func(opts *zap.Options) {
+		opts.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}))
+	origFunc := newMSRReaderFunc
+	defer func() {
+		newMSRReaderFunc = origFunc
+	}()
+
+	newMSRReaderFunc = newTestMSRReader
+	powerLibMock := initializeHostMock()
+
+	client := NewMSRClient(ctrl.Log.WithName("testing"), powerLibMock)
+	defer client.Close()
+	// Ensure that reads occurring before the first two iterations of the worker loop are properly handled
+	util.IterateOverCPUs(powerLibMock, func(cpu power.Cpu, _ power.Core, _ power.Die, _ power.Package) {
+		_, err := client.GetC0ResidencyPercent(cpu)
+		assert.ErrorIs(t, err, ErrCStateResidencyNotYetCalculated)
+	})
+
+	// Wait for the completion of the first two iterations of the worker loop, add 50ms for calculations
+	time.Sleep(2*workersInterval + 50*time.Millisecond)
+
+	// Check if two reads within the same interval are the same
+	// (there is a wait time of two intervals before first metrics are pushed from goroutine)
+	util.IterateOverCPUs(powerLibMock, func(cpu power.Cpu, _ power.Core, _ power.Die, _ power.Package) {
+		val1, err := client.GetC0ResidencyPercent(cpu)
+		assert.Nil(t, err)
+		assert.GreaterOrEqual(t, val1, uint8(0))
+		assert.LessOrEqual(t, val1, uint8(100))
+
+		val2, err := client.GetC0ResidencyPercent(cpu)
+		assert.Nil(t, err)
+		assert.GreaterOrEqual(t, val2, uint8(0))
+		assert.LessOrEqual(t, val2, uint8(100))
+
+		assert.Equal(t, val1, val2)
+	})
+
+	// Check if two reads with gap longer than interval are different
+	util.IterateOverCPUs(powerLibMock, func(cpu power.Cpu, _ power.Core, _ power.Die, _ power.Package) {
+		val1, err := client.GetC0ResidencyPercent(cpu)
+		assert.Nil(t, err)
+		assert.GreaterOrEqual(t, val1, uint8(0))
+		assert.LessOrEqual(t, val1, uint8(100))
+
+		// 50ms for calculations
+		time.Sleep(workersInterval + 50*time.Millisecond)
+
+		val2, err := client.GetC0ResidencyPercent(cpu)
+		assert.Nil(t, err)
+		assert.GreaterOrEqual(t, val2, uint8(0))
+		assert.LessOrEqual(t, val2, uint8(100))
+
+		assert.NotEqual(t, val1, val2)
+	})
+}
+
+func TestGetRAPLEnergyUnit(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true), func(opts *zap.Options) {
+		opts.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}))
+	origFunc := newMSRReaderFunc
+	defer func() {
+		newMSRReaderFunc = origFunc
+	}()
+
+	newMSRReaderFunc = newTestMSRReader
+	powerLibMock := initializeHostMock()
+	client := NewMSRClient(ctrl.Log.WithName("testing"), powerLibMock)
+	defer client.Close()
+
+	// Correctness is checked with default AMD RAPL values
+	energyUnit, err := client.getRAPLEnergyUnit((*(*client.host.Topology().Packages())[0].CPUs())[0])
+	assert.Nil(t, err)
+
+	// Truncated to 6 decimal places after dot to easily compare with turbostat value
+	shift := math.Pow(10, 6)
+	truncated := math.Trunc(energyUnit*shift) / shift
+	assert.Equal(t, float64(0.000015), truncated)
+}
+
+func TestMSRClientClose(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true), func(opts *zap.Options) {
+		opts.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}))
+	origFunc := newMSRReaderFunc
+	defer func() {
+		newMSRReaderFunc = origFunc
+	}()
+
+	newMSRReaderFunc = newTestMSRReader
+	powerLibMock := initializeHostMock()
+	client := NewMSRClient(ctrl.Log.WithName("testing"), powerLibMock)
+	defer client.Close()
+
+	for _, reader := range client.readers {
+		reader.(*testMSRReader).On("close").Return(nil)
+	}
+
+	client.Close()
+
+	for _, reader := range client.readers {
+		reader.(*testMSRReader).AssertExpectations(t)
+	}
+}

--- a/internal/metrics/msr_reader.go
+++ b/internal/metrics/msr_reader.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	msrDirPath       string = "/dev/cpu/"
+	msrFilename      string = "msr"
+	msrReaderBufSize int    = 8
+)
+
+type msrReader interface {
+	read(offset uint64) (uint64, error)
+	close() error
+}
+
+type msrReaderImpl struct {
+	cpu  int
+	file *os.File
+}
+
+func newMSRReader(cpu int) (msrReader, error) {
+	msrFile, err := os.OpenFile(
+		filepath.Join(msrDirPath, strconv.Itoa(cpu), msrFilename),
+		os.O_RDONLY,
+		0660,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open MSR file for CPU %d: %w", cpu, err)
+	}
+
+	return &msrReaderImpl{cpu: cpu, file: msrFile}, nil
+}
+
+func (m *msrReaderImpl) read(offset uint64) (uint64, error) {
+	buf := make([]byte, perfEventReaderBufSize)
+	if _, err := m.file.ReadAt(buf, int64(offset)); err != nil {
+		return 0, fmt.Errorf("failed to read properly opened MSR file for CPU %d: %w", m.cpu, err)
+	}
+
+	return binary.LittleEndian.Uint64(buf), nil
+}
+
+func (m *msrReaderImpl) close() error {
+	return m.file.Close()
+}

--- a/internal/monitoring/msr_collectors.go
+++ b/internal/monitoring/msr_collectors.go
@@ -1,0 +1,49 @@
+package monitoring
+
+import (
+	"github.com/intel/kubernetes-power-manager/internal/metrics"
+	"github.com/intel/power-optimization-library/pkg/power"
+
+	"github.com/go-logr/logr"
+	prom "github.com/prometheus/client_golang/prometheus"
+	ctrlMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func RegisterMSRCollectors(msrClient *metrics.MSRClient, host power.Host, logger logr.Logger) {
+	logger = logger.WithName(msrSubsystem)
+
+	ctrlMetrics.Registry.MustRegister(
+		newPerCPUCollector(
+			prom.BuildFQName(promNamespace, msrSubsystem, "c0_residency_percent"),
+			"Gauge of CPU residency in C0",
+			prom.GaugeValue,
+			host,
+			msrClient.GetC0ResidencyPercent,
+			logger.WithValues(logTypeName, "c0_residency_percent"),
+		),
+		newPerCPUCollector(
+			prom.BuildFQName(promNamespace, msrSubsystem, "cx_residency_percent"),
+			"Gauge of CPU residency in C-states other than C0",
+			prom.GaugeValue,
+			host,
+			msrClient.GetCxResidencyPercent,
+			logger.WithValues(logTypeName, "cx_residency_percent"),
+		),
+		newPerPackageCollector(
+			prom.BuildFQName(promNamespace, msrSubsystem, "package_energy_consumption_joules_total"),
+			"Counter of total package energy consumption in joules",
+			prom.CounterValue,
+			host,
+			msrClient.GetPackageEnergyConsumption,
+			logger.WithValues(logTypeName, "package_energy_consumption_joules_total"),
+		),
+		newPerCoreCollector(
+			prom.BuildFQName(promNamespace, msrSubsystem, "core_energy_consumption_joules_total"),
+			"Counter of total core energy consumption in joules",
+			prom.CounterValue,
+			host,
+			msrClient.GetCoreEnergyConsumption,
+			logger.WithValues(logTypeName, "core_energy_consumption_joules_total"),
+		),
+	)
+}

--- a/internal/monitoring/perf_event_collectors.go
+++ b/internal/monitoring/perf_event_collectors.go
@@ -9,7 +9,9 @@ import (
 	ctrlMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-func registerPerfEventCollectors(perfEventClient *metrics.PerfEventClient, host power.Host, logger logr.Logger) {
+func RegisterPerfEventCollectors(perfEventClient *metrics.PerfEventClient, host power.Host, logger logr.Logger) {
+	logger = logger.WithName(perfSubsystem)
+
 	// Type hardware
 	ctrlMetrics.Registry.MustRegister(
 		newPerCPUCollector(


### PR DESCRIPTION
- Add low-level MSR reader which is wrapper around os.File
- Add higher-level MSR client which is wrapper around MSR readers
- Add couple of supported MSR offsets and client methods for them
- Add C0 and not-C0 residency metrics do MSR client - implementation required adding goroutine workers
- Add MSR metrics collectors
- Add unit tests for MSR client