### PR TITLE
Create CPU scaling component stub

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 # Copy the go source
 COPY build/manager/main.go main.go
 COPY api/ api/
-COPY internal/controller/ internal/controller/
+COPY internal/ internal/
 COPY pkg/ pkg/
 COPY e-sms/ e-sms/
 

--- a/internal/controller/cpuscalingconfiguration_controller_test.go
+++ b/internal/controller/cpuscalingconfiguration_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"go.uber.org/zap/zapcore"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -34,15 +33,26 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	powerv1 "github.com/intel/kubernetes-power-manager/api/v1"
+	"github.com/intel/kubernetes-power-manager/internal/scaling"
 	"github.com/intel/kubernetes-power-manager/pkg/testutils"
 	"github.com/intel/power-optimization-library/pkg/power"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 const (
 	nodeName  string = "TestNode"
 	namespace string = "power-manager"
 )
+
+type ScalingMgrMock struct {
+	scaling.CPUScalingManager
+	mock.Mock
+}
+
+func (m *ScalingMgrMock) UpdateConfig(configs []scaling.CPUScalingOpts) {
+	m.Called(configs)
+}
 
 func createCPUScalingConfigurationReconcilerObject(objs []client.Object) (*CPUScalingConfigurationReconciler, error) {
 	log.SetLogger(zap.New(
@@ -61,7 +71,8 @@ func createCPUScalingConfigurationReconcilerObject(objs []client.Object) (*CPUSc
 	r := &CPUScalingConfigurationReconciler{
 		cl,
 		ctrl.Log.WithName("testing"),
-		scheme.Scheme,
+		s,
+		nil,
 		nil,
 	}
 
@@ -71,7 +82,7 @@ func createCPUScalingConfigurationReconcilerObject(objs []client.Object) (*CPUSc
 func TestCPUScalingConfiguration_Reconcile_InvalidRequests(t *testing.T) {
 	t.Setenv("NODE_NAME", nodeName)
 	r, err := createCPUScalingConfigurationReconcilerObject([]client.Object{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// NOTE: wrong nodename in request is not tested because we do not
 	// have enough information returned to reliably judge if it
@@ -196,17 +207,127 @@ func TestCPUScalingConfiguration_Reconcile_Validation(t *testing.T) {
 		}
 
 		r, err := createCPUScalingConfigurationReconcilerObject([]client.Object{config})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		r.PowerLibrary = nodemk
 
 		_, err = r.Reconcile(context.TODO(), req)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = r.Client.Get(context.TODO(), client.ObjectKey{
 			Name:      nodeName,
 			Namespace: namespace,
 		}, config)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Contains(t, config.Status.Errors, tc.expectedErr)
 	}
+}
+
+func TestCPUScalingConfiguration_Reconcile_Success(t *testing.T) {
+	t.Setenv("NODE_NAME", nodeName)
+
+	req := reconcile.Request{
+		NamespacedName: client.ObjectKey{
+			Name:      nodeName,
+			Namespace: namespace,
+		},
+	}
+	config := &powerv1.CPUScalingConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeName,
+			Namespace: namespace,
+			UID:       "test",
+		},
+		Spec: powerv1.CPUScalingConfigurationSpec{
+			Items: []powerv1.ConfigItem{
+				{
+					CpuIDs: []uint{0, 1},
+					SamplePeriod: metav1.Duration{
+						Duration: 10 * time.Millisecond,
+					},
+				},
+				{
+					CpuIDs: []uint{5},
+					SamplePeriod: metav1.Duration{
+						Duration: 100 * time.Millisecond,
+					},
+				},
+			},
+		},
+	}
+	expectedOpts := []scaling.CPUScalingOpts{
+		{
+			CPUID:        0,
+			SamplePeriod: 10 * time.Millisecond,
+		},
+		{
+			CPUID:        1,
+			SamplePeriod: 10 * time.Millisecond,
+		},
+		{
+			CPUID:        5,
+			SamplePeriod: 100 * time.Millisecond,
+		},
+	}
+
+	cpuListMock := power.CpuList{}
+	for i := 0; i < 10; i++ {
+		mockCore := new(testutils.MockCPU)
+		mockCore.On("GetID").Return(uint(i))
+		cpuListMock = append(cpuListMock, mockCore)
+	}
+	nodemk := new(testutils.MockHost)
+	nodemk.On("GetAllCpus").Return(&cpuListMock)
+
+	mgrmk := new(ScalingMgrMock)
+	mgrmk.On("UpdateConfig", expectedOpts).Return()
+
+	r, err := createCPUScalingConfigurationReconcilerObject([]client.Object{config})
+	assert.NoError(t, err)
+
+	r.PowerLibrary = nodemk
+	r.CPUScalingManager = mgrmk
+
+	_, err = r.Reconcile(context.TODO(), req)
+	assert.NoError(t, err)
+	mgrmk.AssertCalled(t, "UpdateConfig", expectedOpts)
+
+	err = r.Client.Get(context.TODO(), client.ObjectKey{
+		Name:      nodeName,
+		Namespace: namespace,
+	}, config)
+	assert.NoError(t, err)
+	assert.Empty(t, config.Status.Errors)
+}
+
+func TestCPUScalingConfiguration_Reconcile_NotFound(t *testing.T) {
+	t.Setenv("NODE_NAME", nodeName)
+
+	req := reconcile.Request{
+		NamespacedName: client.ObjectKey{
+			Name:      nodeName,
+			Namespace: namespace,
+		},
+	}
+
+	cpuListMock := power.CpuList{}
+	for i := 0; i < 10; i++ {
+		mockCore := new(testutils.MockCPU)
+		mockCore.On("GetID").Return(uint(i))
+		cpuListMock = append(cpuListMock, mockCore)
+	}
+	nodemk := new(testutils.MockHost)
+	nodemk.On("GetAllCpus").Return(&cpuListMock)
+
+	mgrmk := new(ScalingMgrMock)
+	mgrmk.On("UpdateConfig", []scaling.CPUScalingOpts{}).Return()
+
+	r, err := createCPUScalingConfigurationReconcilerObject([]client.Object{})
+	assert.NoError(t, err)
+
+	r.PowerLibrary = nodemk
+	r.CPUScalingManager = mgrmk
+
+	_, err = r.Reconcile(context.TODO(), req)
+	assert.NoError(t, err)
+	mgrmk.AssertCalled(t, "UpdateConfig", []scaling.CPUScalingOpts{})
 }

--- a/internal/metrics/perf_event_reader.go
+++ b/internal/metrics/perf_event_reader.go
@@ -24,10 +24,10 @@ const (
 var syscallRead = syscall.Read
 
 type perfEventValues struct {
-	lastTimeEnabled      uint64
-	lastTimeRunning      uint64
-	lastRawValue         uint64
-	lastScaledValue      uint64
+	lastTimeEnabled uint64
+	lastTimeRunning uint64
+	lastRawValue    uint64
+	lastScaledValue uint64
 }
 
 type perfEventReader interface {

--- a/internal/scaling/common.go
+++ b/internal/scaling/common.go
@@ -1,0 +1,8 @@
+package scaling
+
+import "time"
+
+type CPUScalingOpts struct {
+	CPUID        uint
+	SamplePeriod time.Duration
+}

--- a/internal/scaling/manager.go
+++ b/internal/scaling/manager.go
@@ -1,0 +1,123 @@
+package scaling
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/intel/power-optimization-library/pkg/power"
+)
+
+// Func definitions for unit testing
+var (
+	newCPUScalingWorkerFunc = NewCPUScalingWorker
+)
+
+type CPUScalingManager interface {
+	manager.Runnable
+	UpdateConfig(optList []CPUScalingOpts)
+}
+
+type cpuScalingManagerImpl struct {
+	powerLibrary *power.Host
+	workers      sync.Map
+	logger       logr.Logger
+}
+
+func NewCPUScalingManager(powerLib *power.Host) CPUScalingManager {
+	nodeName := os.Getenv("NODE_NAME")
+
+	mgr := &cpuScalingManagerImpl{
+		powerLibrary: powerLib,
+		logger:       ctrl.Log.WithName("CPUScalingManager").WithName(nodeName),
+	}
+
+	return mgr
+}
+
+func (s *cpuScalingManagerImpl) Start(ctx context.Context) error {
+	<-ctx.Done()
+	s.stop()
+	return nil
+}
+
+func (s *cpuScalingManagerImpl) stop() {
+	s.logger.V(5).Info("stopping all workers")
+
+	managedCPUs := s.getManagedCPUIDs()
+
+	for _, cpuID := range managedCPUs {
+		worker, found := s.workers.LoadAndDelete(cpuID)
+		if found {
+			worker := worker.(CPUScalingWorker)
+			worker.Stop()
+			s.logger.V(5).Info("worker stopped successfully", "cpuID", cpuID)
+		}
+	}
+
+	s.logger.V(5).Info("successfully stopped all")
+}
+
+func (s *cpuScalingManagerImpl) UpdateConfig(optsList []CPUScalingOpts) {
+	incomingManagedCPUs := map[uint]struct{}{}
+	currentManagedCPUs := s.getManagedCPUIDs()
+
+	// create or update workers as per new config
+	for _, opts := range optsList {
+		incomingManagedCPUs[opts.CPUID] = struct{}{}
+
+		worker, found := s.getCPUScalingWorker(opts.CPUID)
+		if !found {
+			s.logger.V(5).Info("creating worker", "cpuID", opts.CPUID)
+
+			s.workers.Store(
+				opts.CPUID,
+				newCPUScalingWorkerFunc(
+					opts.CPUID,
+					s.powerLibrary,
+					&opts,
+				),
+			)
+		} else {
+			worker.UpdateOpts(&opts)
+		}
+	}
+
+	// stop workers on cpus that are no longer managed
+	for _, cpuID := range currentManagedCPUs {
+		if _, contains := incomingManagedCPUs[cpuID]; !contains {
+			s.logger.V(5).Info("stopping  worker", "cpuID", cpuID)
+
+			worker, found := s.workers.LoadAndDelete(cpuID)
+			if !found {
+				s.logger.V(5).Info("worker already stopped", "cpuID", cpuID)
+			} else {
+				worker := worker.(CPUScalingWorker)
+				worker.Stop()
+				s.logger.V(5).Info("worker stopped successfully", "cpuID", cpuID)
+			}
+		}
+	}
+}
+
+func (s *cpuScalingManagerImpl) getManagedCPUIDs() []uint {
+	managedCPUs := make([]uint, 0)
+	s.workers.Range(func(key, value any) bool {
+		managedCPUs = append(managedCPUs, key.(uint))
+		return true
+	})
+
+	return managedCPUs
+}
+
+func (s *cpuScalingManagerImpl) getCPUScalingWorker(cpuID uint) (CPUScalingWorker, bool) {
+	if value, found := s.workers.Load(cpuID); found {
+		return value.(CPUScalingWorker), true
+	}
+
+	return nil, false
+}

--- a/internal/scaling/manager_test.go
+++ b/internal/scaling/manager_test.go
@@ -1,0 +1,234 @@
+package scaling
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/intel/power-optimization-library/pkg/power"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func createNewCPUScalingManager() cpuScalingManagerImpl {
+	log.SetLogger(zap.New(
+		zap.UseDevMode(true),
+		func(opts *zap.Options) {
+			opts.TimeEncoder = zapcore.ISO8601TimeEncoder
+		},
+	))
+
+	return cpuScalingManagerImpl{
+		logger: ctrl.Log.WithName("test-log"),
+	}
+}
+
+func TestCPUScalingManager_Start(t *testing.T) {
+	mgr := createNewCPUScalingManager()
+	w := &workerMock{}
+	w.On("Stop").Return()
+	mgr.workers.Store(uint(0), w)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	cancel()
+	mgr.Start(ctx)
+
+	w.AssertCalled(t, "Stop")
+}
+
+func TestCPUScalingManager_UpdateConfig(t *testing.T) {
+	origNewCPUScalingWorkerFunc := newCPUScalingWorkerFunc
+	t.Cleanup(func() {
+		newCPUScalingWorkerFunc = origNewCPUScalingWorkerFunc
+	})
+	newCPUScalingWorkerFunc = func(cpuID uint, _ *power.Host, opts *CPUScalingOpts) CPUScalingWorker {
+		w := CreateMockWorker(cpuID, opts)
+		return w
+	}
+
+	tcases := []struct {
+		testCase        string
+		initialConfig   []CPUScalingOpts
+		remainingCPUIDs []uint
+		newConfig       []CPUScalingOpts
+	}{
+		{
+			testCase:        "Test Case 1 - New Workers in an empty worker pool",
+			initialConfig:   []CPUScalingOpts{},
+			remainingCPUIDs: []uint{},
+			newConfig: []CPUScalingOpts{
+				{
+					CPUID:        0,
+					SamplePeriod: 10 * time.Millisecond,
+				},
+				{
+					CPUID:        1,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+			},
+		},
+		{
+			testCase: "Test Case 2 - New Workers extending already populated worker pool",
+			initialConfig: []CPUScalingOpts{
+				{
+					CPUID:        0,
+					SamplePeriod: 50 * time.Millisecond,
+				},
+				{
+					CPUID:        1,
+					SamplePeriod: 500 * time.Millisecond,
+				},
+			},
+			remainingCPUIDs: []uint{0, 1},
+			newConfig: []CPUScalingOpts{
+				{
+					CPUID:        0,
+					SamplePeriod: 10 * time.Millisecond,
+				},
+				{
+					CPUID:        1,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+				{
+					CPUID:        2,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+				{
+					CPUID:        3,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+			},
+		},
+		{
+			testCase: "Test Case 3 - Updating existing workers",
+			initialConfig: []CPUScalingOpts{
+				{
+					CPUID:        0,
+					SamplePeriod: 50 * time.Millisecond,
+				},
+				{
+					CPUID:        1,
+					SamplePeriod: 500 * time.Millisecond,
+				},
+			},
+			remainingCPUIDs: []uint{0, 1},
+			newConfig: []CPUScalingOpts{
+				{
+					CPUID:        0,
+					SamplePeriod: 10 * time.Millisecond,
+				},
+				{
+					CPUID:        1,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+			},
+		},
+		{
+			testCase: "Test Case 4 - Removing some workers from existing pool",
+			initialConfig: []CPUScalingOpts{
+				{
+					CPUID:        0,
+					SamplePeriod: 10 * time.Millisecond,
+				},
+				{
+					CPUID:        1,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+				{
+					CPUID:        2,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+				{
+					CPUID:        3,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+			},
+			remainingCPUIDs: []uint{0, 1},
+			newConfig: []CPUScalingOpts{
+				{
+					CPUID:        0,
+					SamplePeriod: 10 * time.Millisecond,
+				},
+				{
+					CPUID:        1,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+			},
+		},
+		{
+			testCase: "Test Case 5 - Removing all workers from existing pool",
+			initialConfig: []CPUScalingOpts{
+				{
+					CPUID:        0,
+					SamplePeriod: 10 * time.Millisecond,
+				},
+				{
+					CPUID:        1,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+				{
+					CPUID:        2,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+				{
+					CPUID:        3,
+					SamplePeriod: 100 * time.Millisecond,
+				},
+			},
+			remainingCPUIDs: []uint{},
+			newConfig:       []CPUScalingOpts{},
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Log(tc.testCase)
+
+		mgr := createNewCPUScalingManager()
+
+		// create workers from initial configuration
+		initialWorkers := make(map[uint]*workerMock, 0)
+		for _, opt := range tc.initialConfig {
+			w := CreateMockWorker(opt.CPUID, &opt)
+			// set up Stap call for workers that should get removed
+			if !slices.Contains(tc.remainingCPUIDs, opt.CPUID) {
+				w.On("Stop").Return()
+			}
+			initialWorkers[opt.CPUID] = w
+			mgr.workers.Store(opt.CPUID, w)
+		}
+		// set up UpdateOpts call for workers that should get updated
+		for _, opt := range tc.newConfig {
+			if slices.Contains(tc.remainingCPUIDs, opt.CPUID) {
+				initialWorkers[opt.CPUID].On("UpdateOpts", &opt).Return()
+			}
+		}
+
+		mgr.UpdateConfig(tc.newConfig)
+
+		// assert all workers from options were created
+		// and have correct values
+		for _, opt := range tc.newConfig {
+			w, found := mgr.getCPUScalingWorker(opt.CPUID)
+			assert.True(t, found)
+			typedW := w.(*workerMock)
+			assert.Equal(t, &opt, typedW.opts)
+		}
+		// assert all initial workers were either stopped or updated
+		for _, opt := range tc.initialConfig {
+			w := initialWorkers[opt.CPUID]
+			if !slices.Contains(tc.remainingCPUIDs, opt.CPUID) {
+				w.AssertCalled(t, "Stop")
+			}
+		}
+		for _, opt := range tc.newConfig {
+			if slices.Contains(tc.remainingCPUIDs, opt.CPUID) {
+				initialWorkers[opt.CPUID].AssertCalled(t, "UpdateOpts", &opt)
+			}
+		}
+	}
+}

--- a/internal/scaling/updater.go
+++ b/internal/scaling/updater.go
@@ -1,0 +1,25 @@
+package scaling
+
+import (
+	"github.com/intel/power-optimization-library/pkg/power"
+)
+
+type CPUScalingUpdater interface {
+	Update(opts *CPUScalingOpts)
+}
+
+type cpuScalingUpdaterImpl struct {
+	powerLibrary *power.Host
+}
+
+func NewCPUScalingUpdater(powerLib *power.Host) CPUScalingUpdater {
+	updater := &cpuScalingUpdaterImpl{
+		powerLibrary: powerLib,
+	}
+
+	return updater
+}
+
+func (u *cpuScalingUpdaterImpl) Update(opts *CPUScalingOpts) {
+	// TODO: implement perodic scaling actions
+}

--- a/internal/scaling/updater_test.go
+++ b/internal/scaling/updater_test.go
@@ -1,0 +1,13 @@
+package scaling
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type updaterMock struct {
+	mock.Mock
+}
+
+func (u *updaterMock) Update(opts *CPUScalingOpts) {
+	u.Called(opts)
+}

--- a/internal/scaling/worker.go
+++ b/internal/scaling/worker.go
@@ -1,0 +1,74 @@
+package scaling
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/intel/power-optimization-library/pkg/power"
+)
+
+var (
+	testHookStopLoop func() bool
+)
+
+type CPUScalingWorker interface {
+	UpdateOpts(opts *CPUScalingOpts)
+	Stop()
+}
+
+type cpuScalingWorkerImpl struct {
+	cpuID      uint
+	opts       atomic.Pointer[CPUScalingOpts]
+	cancelFunc func()
+	waitGroup  sync.WaitGroup
+	updater    CPUScalingUpdater
+}
+
+func NewCPUScalingWorker(cpuID uint, powerLib *power.Host, opts *CPUScalingOpts) CPUScalingWorker {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	worker := &cpuScalingWorkerImpl{
+		cpuID:      cpuID,
+		cancelFunc: cancelFunc,
+		waitGroup:  sync.WaitGroup{},
+	}
+
+	worker.opts.Store(opts)
+	worker.updater = NewCPUScalingUpdater(powerLib)
+	worker.waitGroup.Add(1)
+
+	go worker.runLoop(ctx)
+
+	return worker
+}
+
+func (w *cpuScalingWorkerImpl) UpdateOpts(opts *CPUScalingOpts) {
+	w.opts.Store(opts)
+}
+
+func (w *cpuScalingWorkerImpl) Stop() {
+	w.cancelFunc()
+	w.waitGroup.Wait()
+}
+
+func (w *cpuScalingWorkerImpl) runLoop(ctx context.Context) {
+	defer w.waitGroup.Done()
+
+	for {
+		if testHookStopLoop != nil {
+			if testHookStopLoop() {
+				return
+			}
+		}
+
+		opts := w.opts.Load()
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(opts.SamplePeriod):
+			w.updater.Update(opts)
+		}
+	}
+}

--- a/internal/scaling/worker_test.go
+++ b/internal/scaling/worker_test.go
@@ -1,0 +1,87 @@
+package scaling
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type workerMock struct {
+	mock.Mock
+	cpuID uint
+	opts  *CPUScalingOpts
+}
+
+func (w *workerMock) UpdateOpts(opts *CPUScalingOpts) {
+	w.Called(opts)
+	w.opts = opts
+
+}
+
+func (w *workerMock) Stop() {
+	w.Called()
+}
+
+func CreateMockWorker(cpuID uint, opts *CPUScalingOpts) *workerMock {
+	w := &workerMock{
+		cpuID: cpuID,
+		opts:  opts,
+	}
+	return w
+}
+
+func TestCPUScalingWorker_UpdateOpts(t *testing.T) {
+	expectedOpts := &CPUScalingOpts{
+		SamplePeriod: 10 * time.Millisecond,
+	}
+	wrk := &cpuScalingWorkerImpl{}
+
+	wrk.UpdateOpts(expectedOpts)
+	assert.Equal(t, expectedOpts, wrk.opts.Load())
+}
+
+func TestCPUScalingWorker_Stop(t *testing.T) {
+	cancelFuncCalled := false
+	wrk := &cpuScalingWorkerImpl{
+		waitGroup:  sync.WaitGroup{},
+		cancelFunc: func() { cancelFuncCalled = true },
+	}
+
+	wrk.Stop()
+
+	assert.True(t, cancelFuncCalled)
+}
+
+func TestCPUScalingWorker_runLoop(t *testing.T) {
+	loopCounter := 0
+	t.Cleanup(func() {
+		testHookStopLoop = nil
+	})
+	testHookStopLoop = func() bool {
+		loopCounter++
+		return loopCounter > 1
+	}
+
+	wrk := &cpuScalingWorkerImpl{
+		waitGroup: sync.WaitGroup{},
+	}
+
+	opts := &CPUScalingOpts{
+		SamplePeriod: time.Millisecond,
+	}
+	wrk.opts.Store(opts)
+
+	upd := &updaterMock{}
+	upd.On("Update", opts).Return()
+	wrk.updater = upd
+	wrk.waitGroup.Add(1)
+
+	wrk.runLoop(context.TODO())
+
+	upd.AssertCalled(t, "Update", opts)
+	assert.Panics(t, wrk.waitGroup.Done)
+}


### PR DESCRIPTION
Creates a stub implementation for CPU scaling component connected to CPUScalingConfiguration API.
CPUScalingManager is the overarching interface for controlling workers on assigned CPUs and accepting new scaling configurations.
CPUScalingWorker is run asynchronously and is responsible for storing the scaling configuration tied to the CPU and for calling the updater.
CPUScalingUpdater is run as a part of worker and is responsible for performing actual scaling tasks based on scaling configuration received from the worker.