### PR TITLE
Synchronize helm chart crds with status errors

### DIFF
--- a/helm/crds/templates/crds.yaml
+++ b/helm/crds/templates/crds.yaml
@@ -54,6 +54,13 @@ spec:
             type: object
           status:
             description: CStatesStatus defines the observed state of CStates
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+            required:
+            - errors
             type: object
         type: object
     served: true
@@ -118,11 +125,17 @@ spec:
           status:
             description: PowerConfigStatus defines the observed state of PowerConfig
             properties:
+              errors:
+                items:
+                  type: string
+                type: array
               nodes:
                 description: The Nodes that the Node Agent has been deployed to
                 items:
                   type: string
                 type: array
+            required:
+              - errors
             type: object
         type: object
     served: true
@@ -389,11 +402,15 @@ spec:
           status:
             description: PowerProfileStatus defines the observed state of PowerProfile
             properties:
+              errors:
+                items:
+                  type: string
+                type: array
               id:
                 description: The ID given to the power profile
                 type: integer
             required:
-            - id
+            - errors
             type: object
         type: object
     served: true
@@ -511,10 +528,16 @@ spec:
           status:
             description: PowerWorkloadStatus defines the observed state of PowerWorkload
             properties:
+              errors:
+                items:
+                  type: string
+                type: array
               'node:':
                 description: The Node that this Shared PowerWorkload is associated
                   with
                 type: string
+            required:
+            - errors 
             type: object
         type: object
     served: true
@@ -622,10 +645,16 @@ spec:
           status:
             description: PowerWorkloadStatus defines the observed state of PowerWorkload
             properties:
+              errors:
+                items:
+                  type: string
+                type: array
               'node:':
                 description: The Node that this Shared PowerWorkload is associated
                   with
                 type: string
+            required:
+            - errors
             type: object
         type: object
     served: true
@@ -771,11 +800,9 @@ spec:
             - timeZone
             type: object
           status:
+            description: TimeOfDayCronJobStatus defines the observed state of TimeOfDayCronJob
             properties:
               active:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
                 items:
                   description: "ObjectReference contains enough information to let
                     you inspect or modify the referred object. --- New uses of this
@@ -837,12 +864,18 @@ spec:
                       type: string
                   type: object
                 type: array
+              errors:
+                items:
+                  type: string
+                type: array
               lastScheduleTime:
                 format: date-time
                 type: string
               lastSuccessfulTime:
                 format: date-time
                 type: string
+            required:
+            - errors
             type: object
         type: object
     served: true
@@ -1001,12 +1034,18 @@ spec:
                       type: string
                   type: object
                 type: array
+              errors:
+                items:
+                  type: string
+                type: array
               lastScheduleTime:
                 format: date-time
                 type: string
               lastSuccessfulTime:
                 format: date-time
                 type: string
+              required:
+              - errors
             type: object
         type: object
     served: true
@@ -1155,6 +1194,10 @@ spec:
           status:
             description: TimeOfDayStatus defines the observed state of TimeOfDay
             properties:
+              errors:
+                items:
+                  type: string
+                type: array
               lastSchedule:
                 description: The time of the last update
                 type: string
@@ -1164,6 +1207,8 @@ spec:
               powerProfile:
                 description: PowerProfile associated with Time of Day
                 type: string
+            required:
+            - errors
             type: object
         type: object
     served: true
@@ -1231,6 +1276,13 @@ spec:
             type: object
           status:
             description: UncoreStatus defines the observed state of Uncore
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+            required:
+            - errors
             type: object
         type: object
     served: true


### PR DESCRIPTION
Changes done in this commit
https://github.com/AMDEPYC/kubernetes-power-manager/commit/bcd41bde340943aaf4295e468890e5005eb9a531

were not reflected to helm charts.