### PR TITLE
Handle scheme properly in tests

### DIFF
--- a/internal/controller/common_test.go
+++ b/internal/controller/common_test.go
@@ -91,5 +91,4 @@ func Test_writeStatusErrors(t *testing.T) {
 	updateErr := fmt.Errorf("update error")
 	clientMockObj.On("SubResourceUpdate", ctx, mock.Anything, "status", mock.Anything, mock.Anything).Return(updateErr)
 	assert.ErrorIs(t, writeUpdatedStatusErrsIfRequired(ctx, clientStatusWriter, object, fmt.Errorf("err2")), updateErr, "error updating APi should return that error")
-
 }

--- a/internal/controller/powerprofile_controller_test.go
+++ b/internal/controller/powerprofile_controller_test.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -51,19 +50,25 @@ func createProfileReconcilerObject(objs []runtime.Object) (*PowerProfileReconcil
 		},
 	),
 	)
-	// Register operator types with the runtime scheme.
-	s := scheme.Scheme
 
-	// Add route Openshift scheme
+	// Register operator types with the runtime scheme.
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		return nil, err
+	}
 	if err := powerv1.AddToScheme(s); err != nil {
 		return nil, err
 	}
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).WithScheme(s).Build()
+	client := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
-	// Create a ReconcileNode object with the scheme and fake client.
-	r := &PowerProfileReconciler{cl, ctrl.Log.WithName("testing"), s, nil}
+	// Create a reconciler object with the scheme and fake client.
+	r := &PowerProfileReconciler{
+		Client: client,
+		Log:    ctrl.Log.WithName("testing"),
+		Scheme: s,
+	}
 
 	return r, nil
 }
@@ -115,7 +120,6 @@ func TestPowerProfile_Reconcile_ExclusivePoolCreation(t *testing.T) {
 	host.AddExclusivePool("performance")
 	_, err = r.Reconcile(context.TODO(), req)
 	assert.Nil(t, err)
-
 }
 
 // basic shared pool scenario
@@ -182,7 +186,6 @@ func TestPowerProfile_Reconcile_SharedPoolCreation(t *testing.T) {
 
 	_, err = r.Reconcile(context.TODO(), req)
 	assert.Nil(t, err)
-
 }
 
 func TestPowerProfile_Reconcile_NonPowerProfileNotInLibrary(t *testing.T) {
@@ -1546,7 +1549,6 @@ func TestPowerProfile_Reconcile_FeatureNotSupportedErr(t *testing.T) {
 		_, err = r.Reconcile(context.TODO(), req)
 		assert.ErrorContains(t, err, "Frequency-Scaling - failed to determine driver")
 	}
-
 }
 
 // tests errors returned by the reconciler client using the testutils.ErrClient mock
@@ -1758,7 +1760,6 @@ func TestPowerProfile_Reconcile_UnsupportedGovernor(t *testing.T) {
 		_, err = r.Reconcile(context.TODO(), req)
 		assert.ErrorContains(t, err, "not supported")
 	}
-
 }
 
 func TestPowerProfile_Wrong_Namespace(t *testing.T) {
@@ -1853,12 +1854,9 @@ func TestPowerProfile_Reconcile_SetupPass(t *testing.T) {
 	mgr.On("SetFields", mock.Anything).Return(nil)
 	mgr.On("Add", mock.Anything).Return(nil)
 	mgr.On("GetCache").Return(new(testutils.CacheMk))
-	err = (&PowerProfileReconciler{
-		Client: r.Client,
-		Scheme: r.Scheme,
-	}).SetupWithManager(mgr)
-	assert.Nil(t, err)
 
+	err = r.SetupWithManager(mgr)
+	assert.Nil(t, err)
 }
 func TestPowerProfile_Reconcile_SetupFail(t *testing.T) {
 	r, err := createProfileReconcilerObject([]runtime.Object{})
@@ -1869,10 +1867,6 @@ func TestPowerProfile_Reconcile_SetupFail(t *testing.T) {
 	mgr.On("GetLogger").Return(r.Log)
 	mgr.On("Add", mock.Anything).Return(fmt.Errorf("setup fail"))
 
-	err = (&PowerProfileReconciler{
-		Client: r.Client,
-		Scheme: r.Scheme,
-	}).SetupWithManager(mgr)
+	err = r.SetupWithManager(mgr)
 	assert.Error(t, err)
-
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -80,7 +80,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
This prevents tests from mutating the global scheme object which caused some of them to only work when executed in a specific order.

A new scheme object is now created for each test at setup time. Required APIs are registered to this scheme.

Additionally, this unifies and cleans up the surrounding code across all tests.