### PR TITLE
Add perf counter scaling

### DIFF
--- a/internal/metrics/perf_event_reader.go
+++ b/internal/metrics/perf_event_reader.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"encoding/binary"
 	"fmt"
+	"sync/atomic"
 	"syscall"
 	"unsafe"
 
@@ -14,8 +15,20 @@ const (
 	perfSampleIdentifier = 1 << 16
 	perfIOCFlagGroup     = 1 << 0
 
-	perfEventReaderBufSize = 8
+	// 3 uint64 values: the event value, running time, enabled time
+	perfEventReaderBufSize = 3 * unsafe.Sizeof(uint64(0))
+
+	maxWriteConflictRetries = 10
 )
+
+var syscallRead = syscall.Read
+
+type perfEventValues struct {
+	lastTimeEnabled      uint64
+	lastTimeRunning      uint64
+	lastRawValue         uint64
+	lastScaledValue      uint64
+}
 
 type perfEventReader interface {
 	start() error
@@ -28,17 +41,18 @@ type defaultPerfEventReader struct {
 	kind   int
 	config int
 
+	values atomic.Pointer[perfEventValues]
+
 	fd int
 }
 
 func newDefaultPerfEventReader(cpu, kind, config int) (perfEventReader, error) {
-	dp := defaultPerfEventReader{cpu, kind, config, -1}
-
 	eventAttr := &unix.PerfEventAttr{
-		Type:        uint32(dp.kind),
-		Config:      uint64(dp.config),
+		Type:        uint32(kind),
+		Config:      uint64(config),
 		Size:        uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
 		Bits:        unix.PerfBitDisabled,
+		Read_format: unix.PERF_FORMAT_TOTAL_TIME_RUNNING | unix.PERF_FORMAT_TOTAL_TIME_ENABLED,
 		Sample_type: perfSampleIdentifier,
 	}
 	fd, err := unix.PerfEventOpen(eventAttr, -1, cpu, -1, 0)
@@ -46,7 +60,9 @@ func newDefaultPerfEventReader(cpu, kind, config int) (perfEventReader, error) {
 		return nil, fmt.Errorf("failed to open perf event counter file for CPU %d, type %d, kind %d: %w",
 			cpu, kind, config, err)
 	}
-	dp.fd = fd
+
+	dp := defaultPerfEventReader{cpu: cpu, kind: kind, config: config, fd: fd}
+	dp.values.Store(&perfEventValues{})
 
 	return &dp, nil
 }
@@ -61,10 +77,47 @@ func (p *defaultPerfEventReader) close() error {
 
 func (p *defaultPerfEventReader) read() (uint64, error) {
 	buf := make([]byte, perfEventReaderBufSize)
-	if _, err := syscall.Read(p.fd, buf); err != nil {
-		return 0, fmt.Errorf("failed to read properly created perf event counter file for CPU %d, type %d, kind %d: %w",
-			p.cpu, p.kind, p.config, err)
-	}
+	for attempt := 0; attempt < maxWriteConflictRetries; attempt++ {
+		oldValues := p.values.Load()
 
-	return binary.LittleEndian.Uint64(buf), nil
+		if _, err := syscallRead(p.fd, buf); err != nil {
+			return 0, fmt.Errorf("failed to read properly created perf event counter file for CPU %d, type %d, kind %d: %w",
+				p.cpu, p.kind, p.config, err)
+		}
+
+		rawValue := binary.LittleEndian.Uint64(buf[0:8])
+		timeEnabled := binary.LittleEndian.Uint64(buf[8:16])
+		timeRunning := binary.LittleEndian.Uint64(buf[16:24])
+
+		deltaTimeEnabled := timeEnabled - oldValues.lastTimeEnabled
+		deltaTimeRunning := timeRunning - oldValues.lastTimeRunning
+		deltaValue := rawValue - oldValues.lastRawValue
+
+		if deltaTimeRunning == 0 {
+			// no time counted since last read
+			return oldValues.lastScaledValue, nil
+		}
+		if timeRunning < oldValues.lastTimeRunning || timeEnabled < oldValues.lastTimeEnabled || rawValue < oldValues.lastRawValue {
+			return 0, fmt.Errorf("inconsistent values from perf event counter for CPU %d, type %d, kind %d",
+				p.cpu, p.kind, p.config)
+		}
+		scaledValue := oldValues.lastScaledValue
+		if deltaTimeRunning < deltaTimeEnabled {
+			// multiplexing happened since last read, scaling needs to be done
+			scaledValue += uint64(float64(deltaValue) * float64(deltaTimeEnabled) / float64(deltaTimeRunning))
+		} else {
+			scaledValue += deltaValue
+		}
+		newValues := &perfEventValues{
+			lastTimeEnabled: timeEnabled,
+			lastTimeRunning: timeRunning,
+			lastRawValue:    rawValue,
+			lastScaledValue: scaledValue,
+		}
+		if p.values.CompareAndSwap(oldValues, newValues) {
+			return scaledValue, nil
+		}
+	}
+	return 0, fmt.Errorf("attempts exceeded while trying to update perf event counter for CPU %d, type %d, kind %d",
+		p.cpu, p.kind, p.config)
 }

--- a/internal/metrics/perf_event_reader_test.go
+++ b/internal/metrics/perf_event_reader_test.go
@@ -1,0 +1,114 @@
+package metrics
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockFileDescriptor struct {
+	readData         []byte
+	currentReadIndex int
+	readErr          error
+}
+
+func (m *mockFileDescriptor) Read(fd int, b []byte) (n int, err error) {
+	if m.readErr != nil {
+		return 0, m.readErr
+	}
+	copy(b, m.readData[m.currentReadIndex:])
+	n = len(b)
+	m.currentReadIndex += n
+	return n, nil
+}
+
+func setData(data []byte, value uint64, enabled uint64, running uint64) {
+	binary.LittleEndian.PutUint64(data[0:], value)
+	binary.LittleEndian.PutUint64(data[8:], enabled)
+	binary.LittleEndian.PutUint64(data[16:], running)
+}
+
+func TestDefaultPerfEventReaderRead_Success(t *testing.T) {
+	data := make([]byte, perfEventReaderBufSize)
+	setData(data, 100, 2000, 2000)
+
+	mockFd := &mockFileDescriptor{readData: data}
+	reader := &defaultPerfEventReader{}
+	reader.values.Store(&perfEventValues{})
+
+	originalSyscallRead := syscallRead
+	defer func() { syscallRead = originalSyscallRead }()
+	syscallRead = mockFd.Read
+
+	scaledValue, err := reader.read()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), scaledValue)
+}
+
+func TestDefaultPerfEventReaderRead_Multiplexed(t *testing.T) {
+	data1 := make([]byte, perfEventReaderBufSize)
+	setData(data1, 100, 2000, 2000)
+
+	data2 := make([]byte, perfEventReaderBufSize)
+	setData(data2, 200, 4000, 3000)
+
+	mockFd := &mockFileDescriptor{readData: append(data1, data2...)}
+	reader := &defaultPerfEventReader{}
+	reader.values.Store(&perfEventValues{})
+
+	originalSyscallRead := syscallRead
+	defer func() { syscallRead = originalSyscallRead }()
+	syscallRead = mockFd.Read
+
+	scaledValue, err := reader.read()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), scaledValue)
+
+	scaledValue, err = reader.read()
+	require.NoError(t, err)
+	expectedScaledValue := 100.0 + 100.0/0.5
+	assert.Equal(t, uint64(expectedScaledValue), scaledValue)
+}
+
+func TestDefaultPerfEventReaderRead_NoTimeRunning(t *testing.T) {
+	data := make([]byte, perfEventReaderBufSize)
+	setData(data, 400, 0, 0)
+
+	mockFd := &mockFileDescriptor{readData: data}
+	reader := &defaultPerfEventReader{}
+	reader.values.Store(&perfEventValues{lastScaledValue: 300})
+
+	originalSyscallRead := syscallRead
+	defer func() { syscallRead = originalSyscallRead }()
+	syscallRead = mockFd.Read
+
+	scaledValue, err := reader.read()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(300), scaledValue)
+}
+
+func TestDefaultPerfEventReaderRead_InvalidValues(t *testing.T) {
+	oldData := make([]byte, perfEventReaderBufSize)
+	setData(oldData, 200, 2000, 2000)
+
+	newData := make([]byte, perfEventReaderBufSize)
+	setData(newData, 100, 1700, 1600)
+
+	mockFd := &mockFileDescriptor{readData: append(oldData, newData...)}
+	reader := &defaultPerfEventReader{}
+	reader.values.Store(&perfEventValues{})
+
+	originalSyscallRead := syscallRead
+	defer func() { syscallRead = originalSyscallRead }()
+	syscallRead = mockFd.Read
+
+	scaledValue, err := reader.read()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(200), scaledValue)
+
+	_, err = reader.read()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "inconsistent values")
+}


### PR DESCRIPTION
In case that counter multiplexing happens,
counters need to be scaled in order to get
relevant values.

Addresses #32 