### PR TITLE
Set `LD_LIBRARY_PATH` in VSCode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "go.testEnvVars": {
+        "LD_LIBRARY_PATH": "${workspaceFolder}/e-sms/e_smi/lib"
+    },
+    "terminal.integrated.env.linux": {
+        "LD_LIBRARY_PATH": "${workspaceFolder}/e-sms/e_smi/lib"
+    }
+}


### PR DESCRIPTION
This sets the `LD_LIBRARY_PATH` environment variable in VSCode workspace settings, so that you can run tests both from the integrated terminal and the test runner without setting this variable globally. The solution works both inside and outside of the dev container thanks to the use of `${workspaceFolder}`.