### PR TITLE
Bypass calls to E-SMI in controller tests

### DIFF
--- a/internal/controller/main_test.go
+++ b/internal/controller/main_test.go
@@ -1,0 +1,17 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/intel/power-optimization-library/pkg/power"
+)
+
+func TestMain(m *testing.M) {
+	// TODO: This is a cheap hack to bypass calls to E-SMI in initUncore
+	// in all tests in this package. Ideally, we would make the uncore
+	// feature testable and set this as part of power.Host mock instance
+	// setup, but we don't manage the instance lifecycle properly in most
+	// tests.
+	power.TestHookInitUncoreBypassESMICalls = true
+	m.Run()
+}

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -585,10 +585,6 @@ func SetupDummyFiles(cores int, packages int, diesPerPackage int, cpufiles map[s
 		}
 	}
 	host, err := power.CreateInstanceWithConf("test-node", power.LibConfig{CpuPath: "testing/cpus", ModulePath: "testing/proc.modules", Cores: uint(cores)})
-	// Ignore if error comes from ESMI initialization - we want to run unit tests on any hardware, not only AMD EPYCs
-	if strings.Contains(err.Error(), "ESMI") {
-		err = nil
-	}
 	return host, func() {
 		os.RemoveAll(strings.Split(path, "/")[0])
 	}, err

--- a/power-optimization-library/pkg/power/uncore.go
+++ b/power-optimization-library/pkg/power/uncore.go
@@ -59,6 +59,11 @@ var (
 	kernelModulesFilePath = "/proc/modules"
 )
 
+var (
+	// TestHookInitUncoreBypassESMICalls is a flag used in tests to bypass calls to E-SMI in initUncore.
+	TestHookInitUncoreBypassESMICalls bool
+)
+
 func initUncore() featureStatus {
 	feature := featureStatus{
 		name:     "Uncore frequency",
@@ -75,7 +80,10 @@ func initUncore() featureStatus {
 	defaultUncore.min = 0
 	defaultUncore.max = 2
 
-	esmi_status := C.esmi_df_pstate_range_set(C.uint8_t(0), C.uint8_t(defaultUncore.min), C.uint8_t(defaultUncore.max))
+	var esmi_status C.esmi_status_t
+	if !TestHookInitUncoreBypassESMICalls {
+		esmi_status = C.esmi_df_pstate_range_set(C.uint8_t(0), C.uint8_t(defaultUncore.min), C.uint8_t(defaultUncore.max))
+	}
 	if esmi_status != 0 {
 		feature.err = fmt.Errorf("uncore feature error: %w", fmt.Errorf("DF Pstate range set failed"))
 		return feature
@@ -85,7 +93,10 @@ func initUncore() featureStatus {
 }
 
 func initEsmi() bool {
-	esmi_status := C.esmi_init()
+	var esmi_status C.esmi_status_t
+	if !TestHookInitUncoreBypassESMICalls {
+		esmi_status = C.esmi_init()
+	}
 	if esmi_status != 0 {
 		return false
 	}


### PR DESCRIPTION
This is a workaround which allows bypassing calls to E-SMI in `initUncore()` in all controller tests. This was achieved by introducing a dedicated flag and implementing `TestMain`[^1] for the controller package which sets this flag as part of the global setup.

This is by no means a final solution, but it's cheap and more reliable than the workaround we've used so far, which didn't truly isolate E-SMI in tests.

[^1]: https://pkg.go.dev/testing#hdr-Main