### PR TITLE
Add a shared volume for DPDK runtime data

### DIFF
--- a/build/manifests/ocp/power-node-agent-ds.yaml
+++ b/build/manifests/ocp/power-node-agent-ds.yaml
@@ -46,6 +46,9 @@ spec:
             - mountPath: /var/lib/kubelet/pod-resources/
               name: kubesock
               readOnly: true
+            - mountPath: /var/lib/power-node-agent/pods
+              name: pods
+              readOnly: true
       volumes:
         - name: cpusetup
           hostPath:
@@ -56,3 +59,7 @@ spec:
         - name: kubesock
           hostPath:
             path: /var/lib/kubelet/pod-resources
+        - name: pods
+          hostPath:
+            path: /var/lib/power-node-agent/pods
+            type: DirectoryOrCreate

--- a/build/manifests/power-node-agent-ds.yaml
+++ b/build/manifests/power-node-agent-ds.yaml
@@ -48,6 +48,9 @@ spec:
             - mountPath: /var/lib/kubelet/pod-resources/
               name: kubesock
               readOnly: true
+            - mountPath: /var/lib/power-node-agent/pods
+              name: pods
+              readOnly: true
       volumes:
         - name: cpusetup
           hostPath:
@@ -61,3 +64,7 @@ spec:
         - name: kubesock
           hostPath:
             path: /var/lib/kubelet/pod-resources
+        - name: pods
+          hostPath:
+            path: /var/lib/power-node-agent/pods
+            type: DirectoryOrCreate


### PR DESCRIPTION
This adds a shared `hostPath` volume to which DPDK Pods running on the node can write their runtime data. Power Node Agent will use this volume to discover DPDK telemetry sockets published by these Pods.

The DPDK Pods are expected to mount this volume like below.

```yaml
containers:
  - name: my-dpdk-app
    ...
    env:
      ...
      - name: POD_UID
        valueFrom:
          fieldRef:
            apiVersion: v1
            fieldPath: metadata.uid
    volumeMounts:
      ...
      - name: pods
        mountPath: /var/run/dpdk/rte
        subPathExpr: $(POD_UID)/dpdk/rte
volumes:
  ...
  - name: pods
    hostPath:
      path: /var/lib/power-node-agent/pods
      type: DirectoryOrCreate
```

Note that `mountPath` may need to be adjusted depending on the security context and DPDK configuration[^1].

To enable containers running as non-root to access this volume, create the directory `/var/lib/power-node-agent/pods` on each worker node ahead of time and grant full access to this directory to all users.

```bash
sudo mkdir -p /var/lib/power-node-agent/pods
sudo chmod 777 /var/lib/power-node-agent/pods
```

[^1]: https://doc.dpdk.org/guides/prog_guide/multi_proc_support.html#running-multiple-independent-dpdk-applications