### PR TITLE
fix(helm): adjust frequency range for 'shared' power profile

### DIFF
--- a/helm/kubernetes-power-manager/values.yaml
+++ b/helm/kubernetes-power-manager/values.yaml
@@ -100,7 +100,7 @@ sharedprofile:
   namespace: power-manager
   spec:
     name: "shared"
-    max: 1000
-    min: 1000
+    max:
+    min:
     epp: "power"
     governor: "powersave"


### PR DESCRIPTION
- Removed max/min frequency settings for 'shared' profile.
- Avoided dependencies on frequency values to ensure compliance with hardware limits.

Fixes: #64 ("Error creating the shared profile in Kubernetes cluster")