### PR TITLE
Fixed CPUScalingProfile for incorrect namespace and min/max percent

### DIFF
--- a/examples/example-cpuscalingprofile.yaml
+++ b/examples/example-cpuscalingprofile.yaml
@@ -2,6 +2,7 @@ apiVersion: power.amdepyc.com/v1
 kind: CPUScalingProfile
 metadata:
   name: cpuscalingprofile-sample
+  namespace: power-manager
 spec:
   samplePeriod: 20ms
   cooldownPeriod: 60ms
@@ -9,6 +10,6 @@ spec:
   allowedBusynessDifference: 5
   allowedFrequencyDifference: 10
   scalePercentage: 100
-  min: "100%" # can be percentage of max frequency passed as a string, or regular value in MHz passed as int
-  max: "0%" # can be percentage of max frequency passed as a string, or regular value in MHz passed as int
+  min: "0%" # can be percentage of max frequency passed as a string, or regular value in MHz passed as int
+  max: "100%" # can be percentage of max frequency passed as a string, or regular value in MHz passed as int
   epp: "power"


### PR DESCRIPTION
Current CPUScalingProfile sample is created in the "default" namespace. This needs to be fixed for "power-manager" namespace. 
In addition, the scaling min/max frequency is calculated based on min/max percentages in scaling profile as indicated below:
i.e. scaling min frequency = fmin + (fmax-fmin)*min_percent/100; 
     scaling max frequency = fmin + (fmax-fmin)*max_percent/100; 

By default we expect scaling min = fmin; scaling max = fmax based on the HW limits of specific platform. 

Hence adjusting min_percent to "0%" and max_percent to "100%" to align with this. 