### PR TITLE
dpdk-testapp: configure pod to use host network namespace (#134)

### DIFF
--- a/examples/example-dpdk-testapp.yaml
+++ b/examples/example-dpdk-testapp.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       nodeSelector:
         "feature.node.kubernetes.io/power-node": "true"
+      hostNetwork: true
       containers:
         - name: server
           env:


### PR DESCRIPTION
DPDK and Cx-7 NICs need direct access to the physical NIC (mlx5_0). To run dpdk app in pod, host network namespace is required.