### PR TITLE
helm: add "power" profile to the power config

### DIFF
--- a/helm/manager-chart-library/templates/_power-config.tpl
+++ b/helm/manager-chart-library/templates/_power-config.tpl
@@ -11,5 +11,6 @@ spec:
   - "performance"
   - "balance-performance"
   - "balance-power"
+  - "power"
 
 {{- end -}}


### PR DESCRIPTION
Add a new "power" profile to the Helm power configuration template to extend the list of supported power profiles.