### PR TITLE
Feature/cpuscaling amd pstate epp

### DIFF
--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const userspaceGovernor = "userspace"
+const scalingGovernor = "powersave"
 
 type eppValues struct {
 	cpuScalingProfileSpec powerv1.CPUScalingProfileSpec

--- a/internal/controller/cpuscalingprofile_controller.go
+++ b/internal/controller/cpuscalingprofile_controller.go
@@ -204,7 +204,7 @@ func (r *CPUScalingProfileReconciler) createOrUpdatePowerProfile(scalingProfile 
 			Name:     scalingProfile.Name,
 			Max:      scalingProfile.Spec.Max,
 			Min:      scalingProfile.Spec.Min,
-			Governor: userspaceGovernor,
+			Governor: scalingGovernor,
 			Shared:   false,
 			Epp:      scalingProfile.Spec.Epp,
 		}

--- a/internal/controller/cpuscalingprofile_controller_test.go
+++ b/internal/controller/cpuscalingprofile_controller_test.go
@@ -474,7 +474,7 @@ func TestCPUScalingProfile_Reconcile(t *testing.T) {
 					Name:     "cpuscalingprofile1",
 					Min:      ptr.To(intstr.FromInt32(2000)),
 					Max:      ptr.To(intstr.FromInt32(3000)),
-					Governor: userspaceGovernor,
+					Governor: scalingGovernor,
 					Epp:      powerv1.EPPBalancePerformance,
 					Shared:   false,
 				}, pp.Spec)
@@ -529,7 +529,7 @@ func TestCPUScalingProfile_Reconcile(t *testing.T) {
 					Name:     "cpuscalingprofile1",
 					Min:      ptr.To(intstr.FromInt32(2000)),
 					Max:      ptr.To(intstr.FromInt32(3000)),
-					Governor: userspaceGovernor,
+					Governor: scalingGovernor,
 					Epp:      powerv1.EPPBalancePerformance,
 					Shared:   false,
 				}, pp.Spec)
@@ -748,7 +748,7 @@ func TestCPUScalingProfile_Reconcile(t *testing.T) {
 					Max:      ptr.To(intstr.FromString("80%")),
 					Shared:   false,
 					Epp:      powerv1.EPPBalancePerformance,
-					Governor: userspaceGovernor,
+					Governor: scalingGovernor,
 				}, pp.Spec)
 			},
 			clientObjs: []client.Object{
@@ -835,7 +835,7 @@ func TestCPUScalingProfile_Reconcile(t *testing.T) {
 					Max:      ptr.To(intstr.FromInt32(3000)),
 					Shared:   false,
 					Epp:      powerv1.EPPBalancePerformance,
-					Governor: userspaceGovernor,
+					Governor: scalingGovernor,
 				}, pp.Spec)
 			},
 			clientObjs: []client.Object{
@@ -1595,7 +1595,7 @@ func TestCPUScalingProfile_Reconcile(t *testing.T) {
 					Max:      ptr.To(intstr.FromString("70%")),
 					Shared:   false,
 					Epp:      powerv1.EPPBalancePerformance,
-					Governor: userspaceGovernor,
+					Governor: scalingGovernor,
 				}, pp.Spec)
 				csc := &powerv1.CPUScalingConfiguration{}
 				if !assert.NoError(t, c.Get(context.TODO(),
@@ -1670,7 +1670,7 @@ func TestCPUScalingProfile_Reconcile(t *testing.T) {
 						Max:      ptr.To(intstr.FromString("70%")),
 						Shared:   false,
 						Epp:      powerv1.EPPBalancePerformance,
-						Governor: userspaceGovernor,
+						Governor: scalingGovernor,
 					},
 				},
 				&powerv1.CPUScalingConfiguration{
@@ -1803,7 +1803,7 @@ func TestCPUScalingProfile_Reconcile(t *testing.T) {
 					Name:     "cpuscalingprofile1",
 					Min:      eppDefaults[powerv1.EPPPower].cpuScalingProfileSpec.Min,
 					Max:      eppDefaults[powerv1.EPPPower].cpuScalingProfileSpec.Max,
-					Governor: userspaceGovernor,
+					Governor: scalingGovernor,
 					Epp:      powerv1.EPPPower,
 					Shared:   false,
 				}, pp.Spec)

--- a/internal/scaling/cpu_freq.go
+++ b/internal/scaling/cpu_freq.go
@@ -43,23 +43,42 @@ func isUserspaceGovernor(cpu uint) (bool, error) {
 	return governor == userspaceGovernor, nil
 }
 
-// setCPUFrequency sets the CPU frequency in kHz for the specified CPU using the userspace governor.
+// setCPUFrequency attempts to set the CPU frequency in kHz using the userspace governor.
+// If userspace governor is not supported, it falls back to setting scaling_max_freq
+// (for AMD P-State EPP or similar drivers).
 func setCPUFrequency(cpu uint, frequency uint) error {
-	// check that the userspace governor is enabled
+	// Check if the userspace governor is enabled
 	isUserspace, err := isUserspaceGovernor(cpu)
 	if err != nil {
-		return fmt.Errorf("failed to get userspace governor for CPU %d: %w", cpu, err)
+		return fmt.Errorf("failed to get governor for CPU %d: %w", cpu, err)
 	}
 
-	if !isUserspace {
-		return fmt.Errorf("userspace governor not set for CPU %d", cpu)
+	if isUserspace {
+		// Use userspace governor path
+		scalingSetspeedPath := getCPUFreqPathFunction(cpu, "scaling_setspeed")
+
+		if err := os.WriteFile(scalingSetspeedPath, []byte(fmt.Sprintf("%d", frequency)), 0644); err != nil {
+			return fmt.Errorf("failed to set userspace frequency for CPU %d: %w", cpu, err)
+		}
+
+		return nil
 	}
 
-	scalingSetspeedPath := getCPUFreqPathFunction(cpu, "scaling_setspeed")
-	// Set the desired frequency
-	err = os.WriteFile(scalingSetspeedPath, []byte(fmt.Sprintf("%d", frequency)), 0644)
-	if err != nil {
-		return fmt.Errorf("failed to set frequency for CPU %d: %w", cpu, err)
+	// Fallback: userspace governor not available, try AMD P-State max frequency
+	if err := setCPUMaxFrequency(cpu, frequency); err != nil {
+		return fmt.Errorf("fallback to set max frequency for CPU %d failed: %w", cpu, err)
+	}
+
+	return nil
+}
+
+// setCPUMaxFrequency sets the CPU max frequency in kHz using scaling_max_freq.
+// This is typically used for AMD P-State EPP where userspace governor is unavailable.
+func setCPUMaxFrequency(cpu uint, frequency uint) error {
+	scalingMaxFreqPath := getCPUFreqPathFunction(cpu, "scaling_max_freq")
+
+	if err := os.WriteFile(scalingMaxFreqPath, []byte(fmt.Sprintf("%d", frequency)), 0644); err != nil {
+		return fmt.Errorf("failed to set max frequency for CPU %d: %w", cpu, err)
 	}
 
 	return nil

--- a/internal/scaling/cpu_freq.go
+++ b/internal/scaling/cpu_freq.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	userspaceGovernor = "userspace"
+	powersaveGovernor = "powersave"
 	cpuFreqBasePath   = "/sys/devices/system/cpu/cpu%d/cpufreq"
 )
 
@@ -35,48 +35,27 @@ func getCurrentGovernor(cpu uint) (string, error) {
 	return strings.TrimSpace(string(currentGovernor)), nil
 }
 
-func isUserspaceGovernor(cpu uint) (bool, error) {
+func isPowersaveGovernor(cpu uint) (bool, error) {
 	governor, err := getCurrentGovernor(cpu)
 	if err != nil {
 		return false, fmt.Errorf("failed to read current governor for cpu %d: %w", cpu, err)
 	}
-	return governor == userspaceGovernor, nil
+	return governor == powersaveGovernor, nil
 }
 
-// setCPUFrequency attempts to set the CPU frequency in kHz using the userspace governor.
-// If userspace governor is not supported, it falls back to setting scaling_max_freq
-// (for AMD P-State EPP or similar drivers).
+// setCPUFrequency sets the CPU max frequency in kHz using scaling_max_freq.
 func setCPUFrequency(cpu uint, frequency uint) error {
-	// Check if the userspace governor is enabled
-	isUserspace, err := isUserspaceGovernor(cpu)
+	// Check that the powersave governor is enabled
+	isPowersave, err := isPowersaveGovernor(cpu)
 	if err != nil {
 		return fmt.Errorf("failed to get governor for CPU %d: %w", cpu, err)
 	}
 
-	if isUserspace {
-		// Use userspace governor path
-		scalingSetspeedPath := getCPUFreqPathFunction(cpu, "scaling_setspeed")
-
-		if err := os.WriteFile(scalingSetspeedPath, []byte(fmt.Sprintf("%d", frequency)), 0644); err != nil {
-			return fmt.Errorf("failed to set userspace frequency for CPU %d: %w", cpu, err)
-		}
-
-		return nil
+	if !isPowersave {
+		return fmt.Errorf("powersave governor not set for CPU %d", cpu)
 	}
 
-	// Fallback: userspace governor not available, try AMD P-State max frequency
-	if err := setCPUMaxFrequency(cpu, frequency); err != nil {
-		return fmt.Errorf("fallback to set max frequency for CPU %d failed: %w", cpu, err)
-	}
-
-	return nil
-}
-
-// setCPUMaxFrequency sets the CPU max frequency in kHz using scaling_max_freq.
-// This is typically used for AMD P-State EPP where userspace governor is unavailable.
-func setCPUMaxFrequency(cpu uint, frequency uint) error {
 	scalingMaxFreqPath := getCPUFreqPathFunction(cpu, "scaling_max_freq")
-
 	if err := os.WriteFile(scalingMaxFreqPath, []byte(fmt.Sprintf("%d", frequency)), 0644); err != nil {
 		return fmt.Errorf("failed to set max frequency for CPU %d: %w", cpu, err)
 	}

--- a/internal/scaling/cpu_freq_test.go
+++ b/internal/scaling/cpu_freq_test.go
@@ -77,18 +77,6 @@ func TestGetFrequencyFromPercent(t *testing.T) {
 	}
 }
 
-func TestGetCurrentGovernorUserspace(t *testing.T) {
-	originalGetCPUFreqPath := getCPUFreqPathFunction
-	getCPUFreqPathFunction = func(cpu uint, resource string) string {
-		return overrideGetCPUFreqPath(t, cpu, resource)
-	}
-	defer func() { getCPUFreqPathFunction = originalGetCPUFreqPath }()
-
-	governor, err := getCurrentGovernor(0)
-	require.NoError(t, err)
-	assert.Equal(t, "userspace", governor)
-}
-
 func TestGetCurrentGovernorPowersave(t *testing.T) {
 	originalGetCPUFreqPath := getCPUFreqPathFunction
 	getCPUFreqPathFunction = func(cpu uint, resource string) string {
@@ -99,30 +87,6 @@ func TestGetCurrentGovernorPowersave(t *testing.T) {
 	governor, err := getCurrentGovernor(1)
 	require.NoError(t, err)
 	assert.Equal(t, "powersave", governor)
-}
-
-func TestIsUserspaceGovernor(t *testing.T) {
-	originalGetCPUFreqPath := getCPUFreqPathFunction
-	getCPUFreqPathFunction = func(cpu uint, resource string) string {
-		return overrideGetCPUFreqPath(t, cpu, resource)
-	}
-	defer func() { getCPUFreqPathFunction = originalGetCPUFreqPath }()
-
-	isUserspace, err := isUserspaceGovernor(0)
-	require.NoError(t, err)
-	assert.True(t, isUserspace)
-}
-
-func TestIsUserspaceGovernorNegative(t *testing.T) {
-	originalGetCPUFreqPath := getCPUFreqPathFunction
-	getCPUFreqPathFunction = func(cpu uint, resource string) string {
-		return overrideGetCPUFreqPath(t, cpu, resource)
-	}
-	defer func() { getCPUFreqPathFunction = originalGetCPUFreqPath }()
-
-	isUserspace, err := isUserspaceGovernor(1)
-	require.NoError(t, err)
-	assert.False(t, isUserspace)
 }
 
 func TestSetCPUFrequency(t *testing.T) {


### PR DESCRIPTION
Currently, the CPU Scaling Profile controller creates a power profile using the userspace governor for CPU frequency scaling. However, in amd-pstate active (EPP) mode, the userspace governor is not supported, making amd-pstate passive mode a requirement.

With recent optimizations in amd-pstate active mode, it is now more effective to configure the CPU scaling profile to work in active mode. Therefore, the CPU scaling profile has been updated to use the powersave governor with EPP, and frequency scaling is optimized using scaling_max_freq.